### PR TITLE
console: Add configurable newline command and RETURN key behavior

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -72,6 +72,10 @@ registered (default of 16).
 console library (default of 128).
 * `CONSOLE_PROMPT` - The string displayed to prompt for console input (default
 of "> ").
+* `CONSOLE_RETURN_KEY` - Specifies the character sequence for the console
+return key (default is '\n').
+* `CONSOLE_NEWLINE` - Defines the character sequence for console newline
+(default is '\n').
 * `CONSOLE_BUFFER_ATTRIBUTES` - Extra GCC attributes to add to the internal
 buffers used by the console library (default of none). As an example, this can
 be used in cases where these buffers should be placed in a different linker

--- a/console/include/anchor/console/console_config.h
+++ b/console/include/anchor/console/console_config.h
@@ -14,6 +14,14 @@
 #define CONSOLE_PROMPT "> "
 #endif
 
+#ifndef CONSOLE_RETURN_KEY
+#define CONSOLE_RETURN_KEY '\r'
+#endif
+
+#ifndef CONSOLE_NEWLINE
+#define CONSOLE_NEWLINE "\r\n"
+#endif
+
 #ifndef CONSOLE_BUFFER_ATTRIBUTES
 #define CONSOLE_BUFFER_ATTRIBUTES
 #endif

--- a/console/include/anchor/console/console_config.h
+++ b/console/include/anchor/console/console_config.h
@@ -15,11 +15,11 @@
 #endif
 
 #ifndef CONSOLE_RETURN_KEY
-#define CONSOLE_RETURN_KEY '\r'
+#define CONSOLE_RETURN_KEY '\n'
 #endif
 
 #ifndef CONSOLE_NEWLINE
-#define CONSOLE_NEWLINE "\r\n"
+#define CONSOLE_NEWLINE "\n"
 #endif
 
 #ifndef CONSOLE_BUFFER_ATTRIBUTES

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -114,7 +114,7 @@ static void process_line(void) {
             if (!current_token) {
                 if (cmd) {
                     // too much whitespace
-                    write_str("ERROR: Extra whitespace between arguments\n");
+                    write_str("ERROR: Extra whitespace between arguments"CONSOLE_NEWLINE);
                     return;
                 } else {
                     // empty line - silently fail
@@ -142,13 +142,13 @@ static void process_line(void) {
                 if (!cmd) {
                     write_str("ERROR: Command not found (");
                     write_str(current_token);
-                    write_str(")\n");
+                    write_str(")"CONSOLE_NEWLINE);
                     return;
                 }
             } else {
                 // this is an argument
                 if (arg_index == cmd->num_args) {
-                    write_str("ERROR: Too many arguments\n");
+                    write_str("ERROR: Too many arguments"CONSOLE_NEWLINE);
                     return;
                 }
                 // validate the argument
@@ -159,7 +159,7 @@ static void process_line(void) {
                     write_str(arg->name);
                     write_str("' (");
                     write_str(current_token);
-                    write_str(")\n");
+                    write_str(")"CONSOLE_NEWLINE);
                     return;
                 }
                 cmd->args_ptr[arg_index] = parsed_arg.ptr;
@@ -175,7 +175,7 @@ static void process_line(void) {
         // nothing entered - silently fail
         return;
     } else if (arg_index < get_num_required_args(cmd)) {
-        write_str("ERROR: Too few arguments\n");
+        write_str("ERROR: Too few arguments"CONSOLE_NEWLINE);
         return;
     }
 
@@ -291,7 +291,7 @@ static void do_tab_complete(void) {
     } else if (longest_common_prefix == m_line_len) {
         // multiple matches and we've already entered the longest common prefix,
         // so print all the potential matches as a new line
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         for (uint32_t i = 0; i < m_num_commands; i++) {
             const console_command_def_t* cmd_def = &m_commands[i];
             if (strncmp(cmd_def->name, m_line_buffer, m_line_len)) {
@@ -302,7 +302,7 @@ static void do_tab_complete(void) {
             }
             write_str(cmd_def->name);
         }
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         // re-print the prompt and any valid, pending command
         write_str(CONSOLE_PROMPT);
         if (!m_line_invalid) {
@@ -329,12 +329,12 @@ static void help_command_handler(const help_args_t* args) {
         if (!cmd_def) {
             write_str("ERROR: Unknown command (");
             write_str(args->command);
-            write_str(")\n");
+            write_str(")"CONSOLE_NEWLINE);
             return;
         }
         if (cmd_def->desc) {
             write_str(cmd_def->desc);
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
         write_str("Usage: ");
         write_str(args->command);
@@ -355,7 +355,7 @@ static void help_command_handler(const help_args_t* args) {
                 write_str("]");
             }
         }
-        write_str("\n");
+        write_str(CONSOLE_NEWLINE);
         for (uint32_t i = 0; i < cmd_def->num_args; i++) {
             const console_arg_def_t* arg_def = &cmd_def->args[i];
             write_str("  ");
@@ -369,10 +369,10 @@ static void help_command_handler(const help_args_t* args) {
                 write_str(" - ");
                 write_str(arg_def->desc);
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
     } else {
-        write_str("Available commands:\n");
+        write_str("Available commands:"CONSOLE_NEWLINE);
         // get the max name length for padding
         uint32_t max_name_len = 0;
         for (uint32_t i = 0; i < m_num_commands; i++) {
@@ -395,7 +395,7 @@ static void help_command_handler(const help_args_t* args) {
                 write_str(" - ");
                 write_str(cmd_def->desc);
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
         }
     }
 }
@@ -406,7 +406,7 @@ void console_init(const console_init_t* init) {
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif
-    write_str("\n" CONSOLE_PROMPT);
+    write_str(CONSOLE_NEWLINE CONSOLE_PROMPT);
 }
 
 bool console_command_register(const console_command_def_t* cmd) {
@@ -493,12 +493,12 @@ void console_process(const uint8_t* data, uint32_t length) {
 #endif
             continue;
         }
-        if (c == '\n') {
+        if (c == CONSOLE_RETURN_KEY) {
             if (echo_str) {
                 write_str(echo_str);
                 echo_str = NULL;
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
             process_line();
             reset_line_and_print_prompt();
         } else if (c == CHAR_CTRL_C) {
@@ -506,7 +506,7 @@ void console_process(const uint8_t* data, uint32_t length) {
                 write_str(echo_str);
                 echo_str = NULL;
             }
-            write_str("\n");
+            write_str(CONSOLE_NEWLINE);
             reset_line_and_print_prompt();
             echo_str = NULL;
         } else if (!m_line_invalid && c == '\b') {
@@ -567,7 +567,7 @@ void console_process(const uint8_t* data, uint32_t length) {
 #else
     for (uint32_t i = 0; i < length; i++) {
         const char c = data[i];
-        if (c == '\n') {
+        if (c == CONSOLE_RETURN_KEY) {
             process_line();
             reset_line_and_print_prompt();
         } else if (!m_line_invalid && c >= ' ' && c <= '~') {


### PR DESCRIPTION
To address compatibility issues with popular serial console applications like PuTTY, this commit introduces a configurable parameter in the source code. Previously, the console code used '\n' for newline output and expected '\n' as input to move to the beginning of a new line. However, PuTTY sends '\r' (Carriage Return) when the RETURN key is pressed and expects "\r\n" to move the cursor to the beginning of a new line. With this update, the newline command and the behavior of the RETURN key can be customized to ensure compatibility with PuTTY and similar applications.