### PR TITLE
Init deregisters commands

### DIFF
--- a/console/include/anchor/console/console.h
+++ b/console/include/anchor/console/console.h
@@ -112,6 +112,9 @@ typedef struct {
 // Initializes the console library
 void console_init(const console_init_t* init);
 
+// Deinitializes the console library
+void console_deinit(void);
+
 // Registers a console command with the console library (returns true on success)
 bool console_command_register(const console_command_def_t* cmd);
 

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -470,14 +470,16 @@ static void help_command_handler(const help_args_t* args) {
 void console_init(const console_init_t* init) {
     m_init = *init;
 
-    // make sure to deregister previous commands
-    m_num_commands = 0;
-    memset(m_commands, 0, sizeof(m_commands) / sizeof(m_commands[0]));
-
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif
     write_str(CONSOLE_NEWLINE CONSOLE_PROMPT);
+}
+
+void console_deinit(void) {
+    // deregister commands
+    m_num_commands = 0;
+    memset(m_commands, 0, sizeof(m_commands) / sizeof(m_commands[0]));
 }
 
 bool console_command_register(const console_command_def_t* cmd) {

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -469,6 +469,11 @@ static void help_command_handler(const help_args_t* args) {
 
 void console_init(const console_init_t* init) {
     m_init = *init;
+
+    // make sure to deregister previous commands
+    m_num_commands = 0;
+    memset(m_commands, 0, sizeof(m_commands) / sizeof(m_commands[0]));
+
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -478,7 +478,7 @@ void console_init(const console_init_t* init) {
 void console_deinit(void) {
     // deregister commands
     m_num_commands = 0;
-    memset(m_commands, 0, sizeof(m_commands) / sizeof(m_commands[0]));
+    memset(m_commands, 0, sizeof(m_commands));
 }
 
 bool console_command_register(const console_command_def_t* cmd) {

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -469,7 +469,6 @@ static void help_command_handler(const help_args_t* args) {
 
 void console_init(const console_init_t* init) {
     m_init = *init;
-
 #if CONSOLE_HELP_COMMAND
     console_command_register(help);
 #endif

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -256,17 +256,3 @@ TEST(ConsoleTest, TestPrintLine) {
   process_line("hi\n");
   EXPECT_WRITE_BUFFER("hi\nhi\n> ");
 }
-
-TEST(ConsoleTest, TestInitClearsPreviousCommands) {
-  // try to register an existing command, should fail
-  EXPECT_FALSE(console_command_register(say_hi));
-
-  // re-init, just use dummy init for now
-  const console_init_t init_console = {
-    .write_function = NULL,
-  };
-  console_init(&init_console);
-
-  // try to register same command, should succeed now
-  EXPECT_TRUE(console_command_register(say_hi));
-}

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -256,3 +256,17 @@ TEST(ConsoleTest, TestPrintLine) {
   process_line("hi\n");
   EXPECT_WRITE_BUFFER("hi\nhi\n> ");
 }
+
+TEST(ConsoleTest, TestInitClearsPreviousCommands) {
+  // try to register an existing command, should fail
+  EXPECT_FALSE(console_command_register(say_hi));
+
+  // re-init, just use dummy init for now
+  const console_init_t init_console = {
+    .write_function = NULL,
+  };
+  console_init(&init_console);
+
+  // try to register same command, should succeed now
+  EXPECT_TRUE(console_command_register(say_hi));
+}


### PR DESCRIPTION
Following debugging a test failure of my project which uses Anchor Console, I found that console_init() does not de-register registered commands.

This causes tests harnesses of code using console, designed to use the setup function to re-initialize everything to ensure test independence, to fail if the code tries to ensure that console_command_register() succeeds by returning true.

The proposed solution is to ensure that console_init() wipes the m_commands array when called.