### PR TITLE
Fix off-by-one buffer overflow in console push_char

### DIFF
--- a/console/src/console.c
+++ b/console/src/console.c
@@ -256,6 +256,11 @@ static void reset_line_and_print_prompt(void) {
 }
 
 static void push_char(char c) {
+    if (m_line_len + 1 >= CONSOLE_MAX_LINE_LENGTH) {
+        // no room for the character + null terminator
+        m_line_invalid = true;
+        return;
+    }
     if (m_cursor_pos != m_line_len) {
         // shift the existing data to the right to make space
         memmove(&m_line_buffer[m_cursor_pos + 1], &m_line_buffer[m_cursor_pos], m_line_len - m_cursor_pos);
@@ -264,10 +269,6 @@ static void push_char(char c) {
     m_cursor_pos++;
     m_line_len++;
     m_line_buffer[m_line_len] = '\0';
-    if (m_line_len == CONSOLE_MAX_LINE_LENGTH) {
-        // filled up the line buffer, so mark the line invalid
-        m_line_invalid = true;
-    }
 }
 
 #if CONSOLE_FULL_CONTROL

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -258,9 +258,6 @@ TEST(ConsoleTest, TestPrintLine) {
 }
 
 TEST(ConsoleTest, TestMaxLineLengthBufferFull) {
-  // Send exactly CONSOLE_MAX_LINE_LENGTH printable characters. The buffer
-  // can only hold MAX-1 characters + null terminator, so the last character
-  // must be rejected.
   char input[CONSOLE_MAX_LINE_LENGTH + 1];
   memset(input, 'A', CONSOLE_MAX_LINE_LENGTH);
   input[CONSOLE_MAX_LINE_LENGTH] = '\0';
@@ -282,10 +279,6 @@ TEST(ConsoleTest, TestMaxLineLengthBufferFull) {
 }
 
 TEST(ConsoleTest, TestInsertMiddleOutsideOfSafeBoundary) {
-  // Fill the buffer to two characters short of the max, move cursor back,
-  // then insert via the memmove path to reach max-1 (safe boundary).
-  // Finally append one more character at the end (no memmove) — with the
-  // fix this character should be rejected.
   char input[CONSOLE_MAX_LINE_LENGTH - 1];
   memset(input, 'B', CONSOLE_MAX_LINE_LENGTH - 2);
   input[CONSOLE_MAX_LINE_LENGTH - 2] = '\0';

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -256,3 +256,60 @@ TEST(ConsoleTest, TestPrintLine) {
   process_line("hi\n");
   EXPECT_WRITE_BUFFER("hi\nhi\n> ");
 }
+
+TEST(ConsoleTest, TestMaxLineLengthBufferFull) {
+  // Send exactly CONSOLE_MAX_LINE_LENGTH printable characters. The buffer
+  // can only hold MAX-1 characters + null terminator, so the last character
+  // must be rejected.
+  char input[CONSOLE_MAX_LINE_LENGTH + 1];
+  memset(input, 'A', CONSOLE_MAX_LINE_LENGTH);
+  input[CONSOLE_MAX_LINE_LENGTH] = '\0';
+
+  char expected_echo[CONSOLE_MAX_LINE_LENGTH];
+  memset(expected_echo, 'A', CONSOLE_MAX_LINE_LENGTH - 1);
+  expected_echo[CONSOLE_MAX_LINE_LENGTH - 1] = '\0';
+
+  process_line(input);
+  EXPECT_WRITE_BUFFER(expected_echo);
+
+  process_line("\n");
+  EXPECT_WRITE_BUFFER("\n> ");
+
+  process_line("say_hi\n");
+  EXPECT_WRITE_BUFFER(
+    "say_hi\n"
+    "hi\n> ");
+}
+
+TEST(ConsoleTest, TestInsertMiddleOutsideOfSafeBoundary) {
+  // Fill the buffer to two characters short of the max, move cursor back,
+  // then insert via the memmove path to reach max-1 (safe boundary).
+  // Finally append one more character at the end (no memmove) — with the
+  // fix this character should be rejected.
+  char input[CONSOLE_MAX_LINE_LENGTH - 1];
+  memset(input, 'B', CONSOLE_MAX_LINE_LENGTH - 2);
+  input[CONSOLE_MAX_LINE_LENGTH - 2] = '\0';
+
+  process_line(input);
+  g_console_write_buffer.clear();
+
+  process_line(LEFT_ARROW_SEQUENCE);
+  g_console_write_buffer.clear();
+
+  process_line("X");
+  g_console_write_buffer.clear();
+
+  process_line(RIGHT_ARROW_SEQUENCE);
+  g_console_write_buffer.clear();
+
+  process_line("Z");
+  EXPECT_WRITE_BUFFER("");
+
+  process_line("\n");
+  EXPECT_WRITE_BUFFER("\n> ");
+
+  process_line("say_hi\n");
+  EXPECT_WRITE_BUFFER(
+    "say_hi\n"
+    "hi\n> ");
+}


### PR DESCRIPTION
Summary : Fix an off-by-one buffer overflow in `push_char()` that wrote a null terminator one byte past the end of `m_line_buffer` when the input reached `CONSOLE_MAX_LINE_LENGTH` characters. 

Context : When a user typed `CONSOLE_MAX_LINE_LENGTH` or more characters into the console, `push_char()` would increment `m_line_len` to `CONSOLE_MAX_LINE_LENGTH` and then write `m_line_buffer[m_line_len] = '\0'`, one byte past the end of the buffer. The capacity check (`m_line_invalid = true`) happened *after* the out-of-bounds write, so the damage was already done. Because `m_line_buffer`, `m_line_len`, `m_cursor_pos`, and `m_line_invalid` are adjacent static variables, the overflow could corrupts whichever variable the linker placed immediately after the buffer. When `m_line_len` or `m_cursor_pos` is corrupted, the `uint32_t` subtraction `m_line_len - m_cursor_pos` underflows to a very large value. In my observed use case, it was resulting in a **hardfault** on the microcontroller. 

Fix : Move the capacity check to the top of `push_char()`, *before* any writes. If there is no room for the new character plus a null terminator, the function sets `m_line_invalid` and returns immediately, so neither the `memmove` nor the null terminator write ever touches out-of-bounds memory. 