### PR TITLE
Add support for multiple trailing optional arguments 

### DIFF
--- a/console/src/console.c
+++ b/console/src/console.c
@@ -115,7 +115,7 @@ static uint32_t get_num_required_args(const console_command_def_t* cmd) {
     for (uint32_t i = 0; i < cmd->num_args; i++) {
         const console_arg_def_t* arg = &cmd->args[i];
         if (!arg->is_optional) {
-            continue:
+            continue;
         }
         switch (arg->type) {
             case CONSOLE_ARG_TYPE_INT:

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -51,11 +51,20 @@ static uint32_t m_history_len = 0;
 static int32_t m_history_index = -1;
 #endif
 
-static bool validate_arg_def(const console_arg_def_t* arg) {
+static bool validate_arg_def(const console_arg_def_t* arg, bool* has_optional) {
     switch (arg->type) {
         case CONSOLE_ARG_TYPE_INT:
         case CONSOLE_ARG_TYPE_STR:
-            return arg->name != NULL;
+            if (arg->name == NULL) {
+                return false;
+            }
+            if (arg->is_optional) {
+                *has_optional = true;
+            } else if (*has_optional) {
+                // optinoal args must be trailing
+                return false;
+            }
+            return true;
         default:
             return false;
     }
@@ -103,13 +112,16 @@ static uint32_t get_num_required_args(const console_command_def_t* cmd) {
     }
 
     uint32_t required = cmd->num_args;
-    for (uint32_t i = cmd->num_args; i > 0; i--) {
-        const console_arg_def_t* arg = &cmd->args[i - 1];
-        if ((arg->type == CONSOLE_ARG_TYPE_INT || arg->type == CONSOLE_ARG_TYPE_STR) &&
-            arg->is_optional) {
-            required--;
-        } else {
-            break;
+    for (uint32_t i = 0; i < cmd->num_args; i++) {
+        const console_arg_def_t* arg = &cmd->args[i];
+        if (!arg->is_optional) {
+            continue:
+        }
+        switch (arg->type) {
+            case CONSOLE_ARG_TYPE_INT:
+            case CONSOLE_ARG_TYPE_STR:
+                required--;
+                break;
         }
     }
 
@@ -224,13 +236,13 @@ static void process_line(void) {
 
     if (num_args != cmd->num_args) {
         // set all missing optional arguments to their default values
-        for (uint32_t i = cmd->num_args; i > num_args; i--) {
-            switch (cmd->args[i - 1].type) {
+        for (uint32_t i = num_args; i < cmd->num_args; i++) {
+            switch (cmd->args[i].type) {
                 case CONSOLE_ARG_TYPE_INT:
-                    cmd->args_ptr[i - 1] = (void*)CONSOLE_INT_ARG_DEFAULT;
+                    cmd->args_ptr[i] = (void*)CONSOLE_INT_ARG_DEFAULT;
                     break;
                 case CONSOLE_ARG_TYPE_STR:
-                    cmd->args_ptr[i - 1] = (void*)CONSOLE_STR_ARG_DEFAULT;
+                    cmd->args_ptr[i] = (void*)CONSOLE_STR_ARG_DEFAULT;
                     break;
             }
         }
@@ -494,8 +506,9 @@ bool console_command_register(const console_command_def_t* cmd) {
         return false;
     }
     // validate the arguments
+    bool has_optional = false;
     for (uint32_t i = 0; i < cmd->num_args; i++) {
-        if (!validate_arg_def(cmd->args)) {
+        if (!validate_arg_def(cmd->args, &has_optional)) {
             return false;
         }
     }

--- a/console/src/console.c
+++ b/console/src/console.c
@@ -51,11 +51,11 @@ static uint32_t m_history_len = 0;
 static int32_t m_history_index = -1;
 #endif
 
-static bool validate_arg_def(const console_arg_def_t* arg, bool is_last) {
+static bool validate_arg_def(const console_arg_def_t* arg) {
     switch (arg->type) {
         case CONSOLE_ARG_TYPE_INT:
         case CONSOLE_ARG_TYPE_STR:
-            return arg->name && (!arg->is_optional || is_last);
+            return arg->name != NULL;
         default:
             return false;
     }
@@ -101,18 +101,19 @@ static uint32_t get_num_required_args(const console_command_def_t* cmd) {
     if (cmd->num_args == 0) {
         return 0;
     }
-    const console_arg_def_t* last_arg = &cmd->args[cmd->num_args-1];
-    switch (last_arg->type) {
-        case CONSOLE_ARG_TYPE_INT:
-        case CONSOLE_ARG_TYPE_STR:
-            if (last_arg->is_optional) {
-                return cmd->num_args - 1;
-            } else {
-                return cmd->num_args;
-            }
-        default:
-            return 0;
+
+    uint32_t required = cmd->num_args;
+    for (uint32_t i = cmd->num_args; i > 0; i--) {
+        const console_arg_def_t* arg = &cmd->args[i - 1];
+        if ((arg->type == CONSOLE_ARG_TYPE_INT || arg->type == CONSOLE_ARG_TYPE_STR) &&
+            arg->is_optional) {
+            required--;
+        } else {
+            break;
+        }
     }
+
+    return required;
 }
 #if CONSOLE_HISTORY
 static void history_add_line(void) {
@@ -222,14 +223,16 @@ static void process_line(void) {
     }
 
     if (num_args != cmd->num_args) {
-        // set the optional argument to its default value
-        switch (cmd->args[num_args].type) {
-            case CONSOLE_ARG_TYPE_INT:
-                cmd->args_ptr[num_args] = (void*)CONSOLE_INT_ARG_DEFAULT;
-                break;
-            case CONSOLE_ARG_TYPE_STR:
-                cmd->args_ptr[num_args] = (void*)CONSOLE_STR_ARG_DEFAULT;
-                break;
+        // set all missing optional arguments to their default values
+        for (uint32_t i = cmd->num_args; i > num_args; i--) {
+            switch (cmd->args[i - 1].type) {
+                case CONSOLE_ARG_TYPE_INT:
+                    cmd->args_ptr[i - 1] = (void*)CONSOLE_INT_ARG_DEFAULT;
+                    break;
+                case CONSOLE_ARG_TYPE_STR:
+                    cmd->args_ptr[i - 1] = (void*)CONSOLE_STR_ARG_DEFAULT;
+                    break;
+            }
         }
     }
 
@@ -492,7 +495,7 @@ bool console_command_register(const console_command_def_t* cmd) {
     }
     // validate the arguments
     for (uint32_t i = 0; i < cmd->num_args; i++) {
-        if (!validate_arg_def(cmd->args, i + 1 == cmd->num_args)) {
+        if (!validate_arg_def(cmd->args)) {
             return false;
         }
     }

--- a/console/tests/main.cpp
+++ b/console/tests/main.cpp
@@ -41,6 +41,16 @@ CONSOLE_COMMAND_DEF(stroff, "Prints a string starting from an offset",
   CONSOLE_STR_ARG_DEF(str, "The string"),
   CONSOLE_INT_ARG_DEF(offset, "Offset into the string")
 );
+CONSOLE_COMMAND_DEF(multi_add, "Add numbers with multiple optional args",
+  CONSOLE_INT_ARG_DEF(num1, "First number"),
+  CONSOLE_OPTIONAL_INT_ARG_DEF(num2, "Second (optional) number"),
+  CONSOLE_OPTIONAL_INT_ARG_DEF(num3, "Third (optional) number")
+);
+CONSOLE_COMMAND_DEF(greet, "Greet with optional name and title",
+  CONSOLE_STR_ARG_DEF(greeting, "The greeting word"),
+  CONSOLE_OPTIONAL_STR_ARG_DEF(name, "Name to greet"),
+  CONSOLE_OPTIONAL_STR_ARG_DEF(title, "Title prefix")
+);
 #else
 CONSOLE_COMMAND_DEF(say_hi);
 CONSOLE_COMMAND_DEF(say_bye);
@@ -53,6 +63,16 @@ CONSOLE_COMMAND_DEF(add,
 CONSOLE_COMMAND_DEF(stroff,
   CONSOLE_STR_ARG_DEF(str),
   CONSOLE_INT_ARG_DEF(offset)
+);
+CONSOLE_COMMAND_DEF(multi_add,
+  CONSOLE_INT_ARG_DEF(num1),
+  CONSOLE_OPTIONAL_INT_ARG_DEF(num2),
+  CONSOLE_OPTIONAL_INT_ARG_DEF(num3)
+);
+CONSOLE_COMMAND_DEF(greet,
+  CONSOLE_STR_ARG_DEF(greeting),
+  CONSOLE_OPTIONAL_STR_ARG_DEF(name),
+  CONSOLE_OPTIONAL_STR_ARG_DEF(title)
 );
 #endif
 
@@ -93,6 +113,32 @@ static void stroff_command_handler(const stroff_args_t* args) {
   write_function(buffer);
 }
 
+static void multi_add_command_handler(const multi_add_args_t* args) {
+  char buffer[100];
+  intptr_t result = args->num1;
+  if (args->num2 != CONSOLE_INT_ARG_DEFAULT && args->num3 != CONSOLE_INT_ARG_DEFAULT) {
+    snprintf(buffer, sizeof(buffer), "%ld + %ld + %ld = %ld\n", args->num1, args->num2, args->num3, args->num1 + args->num2 + args->num3);
+  } else if (args->num2 != CONSOLE_INT_ARG_DEFAULT) {
+    result += args->num2;
+    snprintf(buffer, sizeof(buffer), "%ld + %ld = %ld\n", args->num1, args->num2, result);
+  } else {
+    snprintf(buffer, sizeof(buffer), "%ld\n", result);
+  }
+  write_function(buffer);
+}
+
+static void greet_command_handler(const greet_args_t* args) {
+  char buffer[200];
+  if (args->name != CONSOLE_STR_ARG_DEFAULT && args->title != CONSOLE_STR_ARG_DEFAULT) {
+    snprintf(buffer, sizeof(buffer), "%s %s %s\n", args->greeting, args->title, args->name);
+  } else if (args->name != CONSOLE_STR_ARG_DEFAULT) {
+    snprintf(buffer, sizeof(buffer), "%s %s\n", args->greeting, args->name);
+  } else {
+    snprintf(buffer, sizeof(buffer), "%s\n", args->greeting);
+  }
+  write_function(buffer);
+}
+
 int main(int argc, char **argv) {
   const console_init_t init_console = {
     .write_function = write_function,
@@ -104,6 +150,8 @@ int main(int argc, char **argv) {
   console_command_register(minimal);
   console_command_register(add);
   console_command_register(stroff);
+  console_command_register(multi_add);
+  console_command_register(greet);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/console/tests/test_console_help.cpp
+++ b/console/tests/test_console_help.cpp
@@ -22,16 +22,40 @@ static void process_line(const char* str) {
 }
 
 #if CONSOLE_HELP_COMMAND
+TEST(ConsoleTest, TestHelpMultiOptionalArgs) {
+  process_line("help multi_add\n");
+  EXPECT_WRITE_BUFFER(
+    "help multi_add\n"
+    "Add numbers with multiple optional args\n"
+    "Usage: multi_add num1 [num2] [num3]\n"
+    "  num1 - First number\n"
+    "  num2 - Second (optional) number\n"
+    "  num3 - Third (optional) number\n"
+    "> ");
+
+  process_line("help greet\n");
+  EXPECT_WRITE_BUFFER(
+    "help greet\n"
+    "Greet with optional name and title\n"
+    "Usage: greet greeting [name] [title]\n"
+    "  greeting - The greeting word\n"
+    "  name     - Name to greet\n"
+    "  title    - Title prefix\n"
+    "> ");
+}
+
 TEST(ConsoleTest, TestHelpCommand) {
   process_line("help\n");
   EXPECT_WRITE_BUFFER("help\n"
     "Available commands:\n"
-    "  help    - List all commands, or give details about a specific command\n"
-    "  say_hi  - Says hi\n"
-    "  say_bye - Says bye\n"
+    "  help      - List all commands, or give details about a specific command\n"
+    "  say_hi    - Says hi\n"
+    "  say_bye   - Says bye\n"
     "  minimal\n"
-    "  add     - Add two numbers\n"
-    "  stroff  - Prints a string starting from an offset\n"
+    "  add       - Add two numbers\n"
+    "  stroff    - Prints a string starting from an offset\n"
+    "  multi_add - Add numbers with multiple optional args\n"
+    "  greet     - Greet with optional name and title\n"
     "> ");
 
   process_line("help add\n");

--- a/console/tests/test_console_no_help.cpp
+++ b/console/tests/test_console_no_help.cpp
@@ -195,6 +195,69 @@ TEST(ConsoleTest, TestHelpCommand) {
 }
 #endif
 
+TEST(ConsoleTest, TestValidMultiAddCommand) {
+  process_line("multi_add 1 2 3\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add 1 2 3\n"
+    "1 + 2 + 3 = 6\n> ");
+
+  process_line("multi_add 5 10\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add 5 10\n"
+    "5 + 10 = 15\n> ");
+
+  process_line("multi_add 42\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add 42\n"
+    "42\n> ");
+}
+
+TEST(ConsoleTest, TestInvalidMultiAddCommand) {
+  process_line("multi_add\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add\n"
+    "ERROR: Too few arguments\n> ");
+
+  process_line("multi_add 1 2 3 4\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add 1 2 3 4\n"
+    "ERROR: Too many arguments\n> ");
+
+  process_line("multi_add abc\n");
+  EXPECT_WRITE_BUFFER(
+    "multi_add abc\n"
+    "ERROR: Invalid value for 'num1' (abc)\n> ");
+}
+
+TEST(ConsoleTest, TestValidGreetCommand) {
+  process_line("greet hello Alice Dr\n");
+  EXPECT_WRITE_BUFFER(
+    "greet hello Alice Dr\n"
+    "hello Dr Alice\n> ");
+
+  process_line("greet hi Bob\n");
+  EXPECT_WRITE_BUFFER(
+    "greet hi Bob\n"
+    "hi Bob\n> ");
+
+  process_line("greet howdy\n");
+  EXPECT_WRITE_BUFFER(
+    "greet howdy\n"
+    "howdy\n> ");
+}
+
+TEST(ConsoleTest, TestInvalidGreetCommand) {
+  process_line("greet\n");
+  EXPECT_WRITE_BUFFER(
+    "greet\n"
+    "ERROR: Too few arguments\n> ");
+
+  process_line("greet hello Alice Dr Extra\n");
+  EXPECT_WRITE_BUFFER(
+    "greet hello Alice Dr Extra\n"
+    "ERROR: Too many arguments\n> ");
+}
+
 TEST(ConsoleTest, TestTabComplete) {
   process_line("sa\t");
   EXPECT_WRITE_BUFFER("say_");


### PR DESCRIPTION
This PR introduces support for multiple trailing optional arguments : 
- Extend optional argument support from a single trailing optional arg to multiple consecutive trailing optional args
- Update get_num_required_args() to walk backwards and count all trailing optional args, not just the last one
- Update process_line() to set default values for all omitted optional args, not just one 
- Relax validate_arg_def() to no longer restrict optional args to only the last position

Example:
Previously, only the last argument of a command could be optional: 
```c
CONSOLE_COMMAND_DEF(cmd, "description",
CONSOLE_INT_ARG_DEF(required_arg, "A required arg"),
CONSOLE_OPTIONAL_INT_ARG_DEF(optional_arg, "An optional arg")  // only one allowed
); 
```
Now, multiple consecutive trailing arguments can be optional:
```c
CONSOLE_COMMAND_DEF(cmd, "description",
CONSOLE_INT_ARG_DEF(required_arg, "A required arg"),
CONSOLE_OPTIONAL_INT_ARG_DEF(opt1, "First optional arg"), 
CONSOLE_OPTIONAL_INT_ARG_DEF(opt2, "Second optional arg")
);
```

Users can invoke this as cmd 1, cmd 1 2, or cmd 1 2 3. Omitted optional args receive `CONSOLE_INT_ARG_DEFAULT` or `CONSOLE_STR_ARG_DEFAULT` as before.